### PR TITLE
feat: Add branch coverage for lookup (#2)

### DIFF
--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -27,6 +27,9 @@ def _backend_error_handling(backend, reraise=None):
                          backend.actor_ref.actor_class.__name__)
 
 
+lookupBranches = [False] * 16
+
+
 class LibraryController(object):
     pykka_traversable = True
 
@@ -211,37 +214,70 @@ class LibraryController(object):
         .. deprecated:: 1.0
             The ``uri`` argument. Use ``uris`` instead.
         """
-        if sum(o is not None for o in [uri, uris]) != 1:
+        # if sum(o is not None for o in [uri, uris]) != 1:
+        #    raise ValueError('Exactly one of "uri" or "uris" must be set')
+        sum = 0
+        for o in [uri, uris]:
+            lookupBranches[0] = True
+            if o is not None:
+                lookupBranches[1] = True
+                sum += 1
+
+        if sum != 1:
+            lookupBranches[2] = True
             raise ValueError('Exactly one of "uri" or "uris" must be set')
 
-        uris is None or validation.check_uris(uris)
-        uri is None or validation.check_uri(uri)
+        # uris is None or validation.check_uris(uris)
+        if uris is not None:
+            lookupBranches[3] = True
+            validation.check_uris(uris)
+        #uri is None or validation.check_uri(uri)
+        if uri is not None:
+            lookupBranches[4] = True
+            validation.check_uri(uri)
 
         if uri:
+            lookupBranches[5] = True
             deprecation.warn('core.library.lookup:uri_arg')
 
         if uri is not None:
+            lookupBranches[6] = True
             uris = [uri]
 
         futures = {}
-        results = {u: [] for u in uris}
+        #results = {u: [] for u in uris}
+        results = {}
+        for u in uris:
+            lookupBranches[7] = True
+            results[u] = []
 
         # TODO: lookup(uris) to backend APIs
         for backend, backend_uris in self._get_backends_to_uris(uris).items():
+            lookupBranches[8] = True
             if backend_uris:
+                lookupBranches[9] = True
                 for u in backend_uris:
+                    lookupBranches[10] = True
                     futures[(backend, u)] = backend.library.lookup(u)
 
         for (backend, u), future in futures.items():
+            lookupBranches[11] = True
             with _backend_error_handling(backend):
                 result = future.get()
                 if result is not None:
+                    lookupBranches[12] = True
                     validation.check_instances(result, models.Track)
                     # TODO Consider making Track.uri field mandatory, and
                     # then remove this filtering of tracks without URIs.
-                    results[u] = [r for r in result if r.uri]
+                    #results[u] = [r for r in result if r.uri]
+                    for r in result:
+                        lookupBranches[13] = True
+                        if r.uri:
+                            lookupBranches[14] = True
+                            results[u] += [r]
 
         if uri:
+            lookupBranches[15] = True
             return results[uri]
         return results
 

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -4,12 +4,27 @@ import unittest
 
 import mock
 
+
 from mopidy import backend, core
 from mopidy.internal import deprecation
 from mopidy.models import Image, Ref, SearchResult, Track
 
+import pytest
+@pytest.fixture(scope="session", autouse=True)
+def my_fixture():
+    print('INITIALIZATION')
+    yield
+    print('TEAR DOWN')
+    print(len(core.library.lookupBranches))
+    print(core.library.lookupBranches)
+    lookupCoverage = sum(core.library.lookupBranches) / len(core.library.lookupBranches) * 100
+    print("lookup coverage: " + str(lookupCoverage) + "%")
 
 class BaseCoreLibraryTest(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down BaseCoreLibraryTest")
 
     def setUp(self):  # noqa: N802
         dummy1_root = Ref.directory(uri='dummy1:directory', name='dummy1')
@@ -45,6 +60,10 @@ class BaseCoreLibraryTest(unittest.TestCase):
 
 # TODO: split by method
 class CoreLibraryTest(BaseCoreLibraryTest):
+
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down CoreLibraryTest")
 
     def test_get_images_returns_empty_dict_for_no_uris(self):
         self.assertEqual({}, self.core.library.get_images([]))
@@ -282,6 +301,10 @@ class CoreLibraryTest(BaseCoreLibraryTest):
 
 class DeprecatedFindExactCoreLibraryTest(BaseCoreLibraryTest):
 
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down DeprecatedFindExactCoreLibraryTest")
+
     def run(self, result=None):
         with deprecation.ignore('core.library.find_exact'):
             return super(DeprecatedFindExactCoreLibraryTest, self).run(result)
@@ -364,6 +387,10 @@ class DeprecatedFindExactCoreLibraryTest(BaseCoreLibraryTest):
 
 class DeprecatedLookupCoreLibraryTest(BaseCoreLibraryTest):
 
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down DeprecatedLookupCoreLibraryTest")
+
     def run(self, result=None):
         with deprecation.ignore('core.library.lookup:uri_arg'):
             return super(DeprecatedLookupCoreLibraryTest, self).run(result)
@@ -391,6 +418,10 @@ class DeprecatedLookupCoreLibraryTest(BaseCoreLibraryTest):
 
 
 class LegacyFindExactToSearchLibraryTest(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down LegacyFindExactToSearchLibraryTest")
 
     def run(self, result=None):
         with deprecation.ignore('core.library.find_exact'):
@@ -431,6 +462,10 @@ class LegacyFindExactToSearchLibraryTest(unittest.TestCase):
 
 class MockBackendCoreLibraryBase(unittest.TestCase):
 
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down MockBackendCoreLibraryBase")
+
     def setUp(self):  # noqa: N802
         dummy_root = Ref.directory(uri='dummy:directory', name='dummy')
 
@@ -447,6 +482,10 @@ class MockBackendCoreLibraryBase(unittest.TestCase):
 
 @mock.patch('mopidy.core.library.logger')
 class BrowseBadBackendTest(MockBackendCoreLibraryBase):
+
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down BrowseBadBackendTest")
 
     def test_backend_raises_exception_for_root(self, logger):
         # Might happen if root_directory is a property for some weird reason.
@@ -478,6 +517,10 @@ class BrowseBadBackendTest(MockBackendCoreLibraryBase):
 @mock.patch('mopidy.core.library.logger')
 class GetDistinctBadBackendTest(MockBackendCoreLibraryBase):
 
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down GetDistinctBadBackendTest")
+
     def test_backend_raises_exception(self, logger):
         self.library.get_distinct.return_value.get.side_effect = Exception
         self.assertEqual(set(), self.core.library.get_distinct('artist'))
@@ -501,6 +544,10 @@ class GetDistinctBadBackendTest(MockBackendCoreLibraryBase):
 
 @mock.patch('mopidy.core.library.logger')
 class GetImagesBadBackendTest(MockBackendCoreLibraryBase):
+
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down GetImagesBadBackendTest")
 
     def test_backend_raises_exception(self, logger):
         uri = 'dummy:/1'
@@ -541,6 +588,9 @@ class GetImagesBadBackendTest(MockBackendCoreLibraryBase):
 
 @mock.patch('mopidy.core.library.logger')
 class LookupByUrisBadBackendTest(MockBackendCoreLibraryBase):
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down LookupByUrisBadBackendTest")
 
     def test_backend_raises_exception(self, logger):
         uri = 'dummy:/1'
@@ -588,6 +638,10 @@ class LookupByUrisBadBackendTest(MockBackendCoreLibraryBase):
 @mock.patch('mopidy.core.library.logger')
 class RefreshBadBackendTest(MockBackendCoreLibraryBase):
 
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down RefreshBadBackendTest")
+
     def test_backend_raises_exception(self, logger):
         self.library.refresh.return_value.get.side_effect = Exception
         self.core.library.refresh()
@@ -601,6 +655,10 @@ class RefreshBadBackendTest(MockBackendCoreLibraryBase):
 
 @mock.patch('mopidy.core.library.logger')
 class SearchBadBackendTest(MockBackendCoreLibraryBase):
+
+    @classmethod
+    def tearDownClass(cls):
+        print("Tear down SearchBadBackendTest")
 
     def test_backend_raises_exception(self, logger):
         self.library.search.return_value.get.side_effect = Exception

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -22,10 +22,6 @@ def my_fixture():
 
 class BaseCoreLibraryTest(unittest.TestCase):
 
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down BaseCoreLibraryTest")
-
     def setUp(self):  # noqa: N802
         dummy1_root = Ref.directory(uri='dummy1:directory', name='dummy1')
         self.backend1 = mock.Mock()
@@ -60,10 +56,6 @@ class BaseCoreLibraryTest(unittest.TestCase):
 
 # TODO: split by method
 class CoreLibraryTest(BaseCoreLibraryTest):
-
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down CoreLibraryTest")
 
     def test_get_images_returns_empty_dict_for_no_uris(self):
         self.assertEqual({}, self.core.library.get_images([]))
@@ -301,10 +293,6 @@ class CoreLibraryTest(BaseCoreLibraryTest):
 
 class DeprecatedFindExactCoreLibraryTest(BaseCoreLibraryTest):
 
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down DeprecatedFindExactCoreLibraryTest")
-
     def run(self, result=None):
         with deprecation.ignore('core.library.find_exact'):
             return super(DeprecatedFindExactCoreLibraryTest, self).run(result)
@@ -387,10 +375,6 @@ class DeprecatedFindExactCoreLibraryTest(BaseCoreLibraryTest):
 
 class DeprecatedLookupCoreLibraryTest(BaseCoreLibraryTest):
 
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down DeprecatedLookupCoreLibraryTest")
-
     def run(self, result=None):
         with deprecation.ignore('core.library.lookup:uri_arg'):
             return super(DeprecatedLookupCoreLibraryTest, self).run(result)
@@ -418,10 +402,6 @@ class DeprecatedLookupCoreLibraryTest(BaseCoreLibraryTest):
 
 
 class LegacyFindExactToSearchLibraryTest(unittest.TestCase):
-
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down LegacyFindExactToSearchLibraryTest")
 
     def run(self, result=None):
         with deprecation.ignore('core.library.find_exact'):
@@ -462,10 +442,6 @@ class LegacyFindExactToSearchLibraryTest(unittest.TestCase):
 
 class MockBackendCoreLibraryBase(unittest.TestCase):
 
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down MockBackendCoreLibraryBase")
-
     def setUp(self):  # noqa: N802
         dummy_root = Ref.directory(uri='dummy:directory', name='dummy')
 
@@ -482,10 +458,6 @@ class MockBackendCoreLibraryBase(unittest.TestCase):
 
 @mock.patch('mopidy.core.library.logger')
 class BrowseBadBackendTest(MockBackendCoreLibraryBase):
-
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down BrowseBadBackendTest")
 
     def test_backend_raises_exception_for_root(self, logger):
         # Might happen if root_directory is a property for some weird reason.
@@ -517,10 +489,6 @@ class BrowseBadBackendTest(MockBackendCoreLibraryBase):
 @mock.patch('mopidy.core.library.logger')
 class GetDistinctBadBackendTest(MockBackendCoreLibraryBase):
 
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down GetDistinctBadBackendTest")
-
     def test_backend_raises_exception(self, logger):
         self.library.get_distinct.return_value.get.side_effect = Exception
         self.assertEqual(set(), self.core.library.get_distinct('artist'))
@@ -544,10 +512,6 @@ class GetDistinctBadBackendTest(MockBackendCoreLibraryBase):
 
 @mock.patch('mopidy.core.library.logger')
 class GetImagesBadBackendTest(MockBackendCoreLibraryBase):
-
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down GetImagesBadBackendTest")
 
     def test_backend_raises_exception(self, logger):
         uri = 'dummy:/1'
@@ -588,9 +552,6 @@ class GetImagesBadBackendTest(MockBackendCoreLibraryBase):
 
 @mock.patch('mopidy.core.library.logger')
 class LookupByUrisBadBackendTest(MockBackendCoreLibraryBase):
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down LookupByUrisBadBackendTest")
 
     def test_backend_raises_exception(self, logger):
         uri = 'dummy:/1'
@@ -638,10 +599,6 @@ class LookupByUrisBadBackendTest(MockBackendCoreLibraryBase):
 @mock.patch('mopidy.core.library.logger')
 class RefreshBadBackendTest(MockBackendCoreLibraryBase):
 
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down RefreshBadBackendTest")
-
     def test_backend_raises_exception(self, logger):
         self.library.refresh.return_value.get.side_effect = Exception
         self.core.library.refresh()
@@ -655,10 +612,6 @@ class RefreshBadBackendTest(MockBackendCoreLibraryBase):
 
 @mock.patch('mopidy.core.library.logger')
 class SearchBadBackendTest(MockBackendCoreLibraryBase):
-
-    @classmethod
-    def tearDownClass(cls):
-        print("Tear down SearchBadBackendTest")
 
     def test_backend_raises_exception(self, logger):
         self.library.search.return_value.get.side_effect = Exception


### PR DESCRIPTION
This pull request adds an ad-hoc branch coverage check for `lookup`.

`$ python -m pytest -s`

`lookup` has 100% coverage.

fixes #2